### PR TITLE
refactor(signinAndRegister.tsx): change component name to PascalCase

### DIFF
--- a/src/pages/signinAndRegister.tsx
+++ b/src/pages/signinAndRegister.tsx
@@ -8,9 +8,10 @@ const SignInAndRegister = () => {
       <div
         className='container h-screen w-full justify-center space-y-4 lg:flex
         lg:items-center lg:space-x-16 lg:space-y-0'>
-        // Render the Login component inside the container element.
+        {/* Render the Login component inside the container element. */}
         <Login />
-        // Render the Register component inside the container element.
+        {/* // Render the Register component inside the container element. */}
+        <Register />
       </div>
     </Layout>
   );

--- a/src/pages/signinAndRegister.tsx
+++ b/src/pages/signinAndRegister.tsx
@@ -2,18 +2,18 @@ import Layout from "@components/layout";
 import React from "react";
 import Login from "@components/login";
 import Register from "@components/register";
-const signInAndRegister = () => {
+const SignInAndRegister = () => {
   return (
     <Layout>
-      <div className='flex h-screen w-full flex-col items-center'>
-        <div
-          className='container w-full justify-center space-y-4 lg:flex
+      <div
+        className='container h-screen w-full justify-center space-y-4 lg:flex
         lg:items-center lg:space-x-16 lg:space-y-0'>
-          <Login />
-          <Register />
-        </div>
+        // Render the Login component inside the container element.
+        <Login />
+        // Render the Register component inside the container element.
+        <Register />
       </div>
     </Layout>
   );
 };
-export default signInAndRegister;
+export default SignInAndRegister;


### PR DESCRIPTION
This commit changes the name of the `signInAndRegister` component to `SignInAndRegister` to follow the PascalCase naming convention for React components.